### PR TITLE
Added RamseteDrive interface

### DIFF
--- a/wpi/src/main/java/com/team6479/lib/subsystems/RamseteDrive.java
+++ b/wpi/src/main/java/com/team6479/lib/subsystems/RamseteDrive.java
@@ -7,13 +7,22 @@ import edu.wpi.first.wpilibj2.command.RamseteCommand;
 
 public interface RamseteDrive {
   public Pose2d getPose();
+
   public DifferentialDriveWheelSpeeds getWheelSpeeds();
+
   public void tankDriveVolts(double leftVolts, double rightVolts);
+
   public void resetEncoders();
+
   public double getLeftEncoderPos();
+
   public double getRightEncoderPos();
+
   public double getLeftEncoderVel();
+
   public double getRightEncoderVel();
+
   public double getHeading();
+
   public RamseteCommand getRamseteCommand(Trajectory trajectory);
 }

--- a/wpi/src/main/java/com/team6479/lib/subsystems/RamseteDrive.java
+++ b/wpi/src/main/java/com/team6479/lib/subsystems/RamseteDrive.java
@@ -1,0 +1,19 @@
+package com.team6479.lib.subsystems;
+
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.kinematics.DifferentialDriveWheelSpeeds;
+import edu.wpi.first.wpilibj.trajectory.Trajectory;
+import edu.wpi.first.wpilibj2.command.RamseteCommand;
+
+public interface RamseteDrive {
+  public Pose2d getPose();
+  public DifferentialDriveWheelSpeeds getWheelSpeeds();
+  public void tankDriveVolts(double leftVolts, double rightVolts);
+  public void resetEncoders();
+  public double getLeftEncoderPos();
+  public double getRightEncoderPos();
+  public double getLeftEncoderVel();
+  public double getRightEncoderVel();
+  public double getHeading();
+  public RamseteCommand getRamseteCommand(Trajectory trajectory);
+}


### PR DESCRIPTION
This interface adds some required methods to make pathfinding work properly. See [Ramsete Docs](https://docs.wpilib.org/en/latest/docs/software/advanced-control/trajectories/index.html) for further explanation on WPI's Ramsete.